### PR TITLE
migrate to ftpmirror.gnu.org

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -109,7 +109,7 @@ jobs:
           cip cache-key
 
       - name: Cache CPAN modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.cip
           key: ${{ runner.os }}-build-${{ steps.cache-key.outputs.key }}

--- a/alienfile
+++ b/alienfile
@@ -21,7 +21,7 @@ share {
   requires 'Alien::m4'    => '0.08';
 
   plugin Download => (
-    url => 'https://ftp.gnu.org/gnu/gmp',
+    url => 'https://ftpmirror.gnu.org/gnu/gmp',
     filter => qr/^gmp-.*\.tar\.bz2$/,
     version => qr/([0-9\.]+)/,
   );


### PR DESCRIPTION
ftp.gnu.org is often slow or unresponsive causing failures in our build automation systems.  I have modified alienfile to use ftpmirror.gnu.org to download gmp.  In our testing this has been more performant and caused fewer failures in our builds.

I also updated the linux workflow to use the latest actions/cache version because the version it was using has been discontinued. 